### PR TITLE
Rework mpi bindings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,4 +96,4 @@ jobs:
 
       - name: Run tests (C++ Bindings, MPI, n=3)
         run: |
-          PRESSIO-LINALG-CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi
+          PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,4 +96,4 @@ jobs:
 
       - name: Run tests (C++ Bindings, MPI, n=3)
         run: |
-          mpirun -n 3 python -m pytest tests/* --with-mpi
+          PRESSIO-LINALG-CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,17 +41,6 @@ jobs:
         run: |
           python -m pip install mpi4py
 
-      # - name: Setup Miniconda
-      #   uses: conda-incubator/setup-miniconda@v2.2.0
-      #   with:
-      #     miniconda-version: "latest"
-      #     python-version: ${{ matrix.python-version }}
-
-      # - name: Setup mpi4py
-      #   run: |
-      #     python -m pip install --upgrade pip
-      #     conda install -c conda-forge mpi4py ${{ matrix.mpi }}
-
       - name: Set Environment Variables
         run: |
           echo "OMPI_ALLOW_RUN_AS_ROOT=1" >> $GITHUB_ENV
@@ -92,8 +81,8 @@ jobs:
           echo $PWD
           python -m pip install --upgrade pip
           pip list
-          export PRESSIO_LINALG_CPP=1 pip install .
+          PRESSIO_LINALG_CPP=1 pip install .
 
       - name: Run tests (C++ Bindings, MPI, n=3)
         run: |
-          export PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi
+          PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,8 +92,8 @@ jobs:
           echo $PWD
           python -m pip install --upgrade pip
           pip list
-          PRESSIO_LINALG_CPP=1 pip install .
+          export PRESSIO_LINALG_CPP=1 pip install .
 
       - name: Run tests (C++ Bindings, MPI, n=3)
         run: |
-          PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi
+          export PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,6 @@ jobs:
           echo $PWD
           python -m pip install --upgrade pip
           pip list
-          export PRESSIO_LINALG_CPP=1
+          echo "PRESSIO_LINALG_CPP=1" >> $GITHUB_ENV
           pip install .
           mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,24 +65,19 @@ jobs:
           echo $GITHUB_WORKSPACE
           git status
 
-      - name: Install package (Light mode)
+      - name: Install and test package (Light mode)
         run: |
           echo $PWD
           python -m pip install --upgrade pip
           pip list
           pip install .
-
-      - name: Run tests (Light mode, MPI, n=3)
-        run: |
           mpirun -n 3 python -m pytest tests/* --with-mpi
 
-      - name: Install package (C++ Bindings)
+      - name: Install and test package (C++ Bindings)
         run: |
           echo $PWD
           python -m pip install --upgrade pip
           pip list
-          PRESSIO_LINALG_CPP=1 pip install .
-
-      - name: Run tests (C++ Bindings, MPI, n=3)
-        run: |
-          PRESSIO_LINALG_CPP=1 mpirun -n 3 python -m pytest tests/* --with-mpi
+          export PRESSIO_LINALG_CPP=1
+          pip install .
+          mpirun -n 3 python -m pytest tests/* --with-mpi

--- a/README.md
+++ b/README.md
@@ -2,62 +2,6 @@
 
 # pressio-linalg
 
-## Current installation (subject to change)
-
-This README will change as we finalize the installation process for the repository. For now, we are working on supporting parallel C++ bindings. To install and test, begin by cloning the repository:
-```sh
-git clone https://github.com/Pressio/pressio-linalg.git
-cd pressio-linalg
-```
-### Light Mode
-
-To install in  Light mode (Python only), just run
-```sh
-pip install .
-```
-from the project directory.
-
-### Heavy Mode
-
-For now, "Heavy Mode" just means Python with C++ bindings (e.g. I have not incorporated Trilinos or Pressio yet). To install with these bindings, you need to define two environment variables:
-
-```sh
-export MPI_BASE_DIR=<path-to-MPI-install>
-export MPI4PY_INCLUDE_DIR=<path-to-mpi4py-include-dir>
-```
-You can find the include directory of mpi4py by running this Python code, either on the command line or in a script:
-```python
-import mpi4py
-print(mpi4py.get_include())
-```
-With this in mind, you can export the necessary environment variables automatically with these commands:
-```sh
-export MPI_BASE_DIR=$(dirname $(dirname $(which mpicxx)))
-export MPI4PY_INCLUDE_DIR=$(python -c 'import mpi4py; print(mpi4py.get_include())')
-```
-Once these have been set, run
-```sh
-PRESSIO-LINALG-CPP=1 pip install .
-```
-to install the package with the C++ bindings.
-
-## Testing the Bindings
-
-Once the package has installed, you can test the Python/C++ bindings by running
-```sh
-python tests/test_bindings.py
-```
-This file calls public-facing functions and prints the output from either the Python or C++ implementation (depending on how you installed the package). The source of the function is clear in the output--e.g. `C++ received the world`.
-
-## Testing in General
-
-To run the other tests on the code, run
-
-```sh
-mpirun -n <np> python -m pytest tests/* --with-mpi
-```
-where, `<np>` is the number of processors you would like to use.
-
 <!-- ---
 
 ## Installation

--- a/pressiolinalg/linalg.py
+++ b/pressiolinalg/linalg.py
@@ -13,7 +13,7 @@ from mpi4py import MPI
 
 
 def _basic_func_via_python(vec):
-    print("myfunc purely python")
+    print("Using only Python")
 
 def _basic_mpi_func_via_python(vec, comm):
     rank = comm.Get_rank()

--- a/pressiolinalg/linalg.py
+++ b/pressiolinalg/linalg.py
@@ -13,7 +13,9 @@ from mpi4py import MPI
 
 
 def _basic_func_via_python(vec):
-    print("Using only Python")
+    status = "Using only Python"
+    print(status)
+    return status
 
 def _basic_mpi_func_via_python(vec, comm):
     rank = comm.Get_rank()

--- a/pressiolinalg/linalg.py
+++ b/pressiolinalg/linalg.py
@@ -14,7 +14,6 @@ from mpi4py import MPI
 
 def _basic_func_via_python(vec):
     status = "Using only Python"
-    print(status)
     return status
 
 def _basic_mpi_func_via_python(vec, comm):

--- a/pressiolinalg/linalg.py
+++ b/pressiolinalg/linalg.py
@@ -20,10 +20,8 @@ def _basic_mpi_func_via_python(vec, comm):
     print(f"Python rank: {rank}")
 
 def _basic_print_comm(comm):
-    if comm == MPI.COMM_WORLD:
-        return "Python received the world"
-    else:
-        return "Python received something else"
+    print("Python received comm")
+    return MPI._addressof(comm)
 
 # np.max(a, axis=None, out=None, keepdims=<no value>, initial=<no value>, where=<no value>)
 def _basic_max_via_python(vec, comm):
@@ -162,6 +160,7 @@ try:
 except ImportError as e:
     myfunc = _basic_func_via_python
     print_comm = _basic_print_comm
+    # direct_print_comm = _basic_print_comm
     # myfuncMPI = _basic_mpi_func_via_python
     # max = _basic_max_via_python
     # min = _basic_min_via_python

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ if os.environ.get("PRESSIO_LINALG_FIND_TRILINOS"):
     trilinosBaseDir = os.environ.get("PRESSIO_LINALG_FIND_TRILINOS")
     pressio_python_only = False
 
+if pressio_cpp_bindings:
+    print("Installing package with CPP bindings")
+
 # ----------------------------------------------
 # Metadata
 # ----------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,6 @@ if os.environ.get("PRESSIO_LINALG_FIND_TRILINOS"):
     trilinosBaseDir = os.environ.get("PRESSIO_LINALG_FIND_TRILINOS")
     pressio_python_only = False
 
-if pressio_cpp_bindings:
-    print("Installing package with CPP bindings")
-
 # ----------------------------------------------
 # Metadata
 # ----------------------------------------------

--- a/src/main_binder.cc
+++ b/src/main_binder.cc
@@ -18,8 +18,10 @@ using py_c_arr  = pybind11::array_t<scalar_t, pybind11::array::c_style>;
 using py_f_arr  = pybind11::array_t<scalar_t, pybind11::array::f_style>;
 
 // Simple function to serial bindings
-void _myfunc(py_f_arr vec) {
-  std::cout << "Using C++ bindings";
+std::string _myfunc(py_f_arr vec) {
+  std::string status = "Using C++ bindings";
+  std::cout << status << std::endl;
+  return status;
 }
 
 MPI_Comm* get_mpi_comm(py::object py_comm) {

--- a/src/main_binder.cc
+++ b/src/main_binder.cc
@@ -11,48 +11,6 @@
 
 
 namespace py = pybind11;
-
-// Create a type that the C++ compiler will recognize
-struct mpi4py_comm {
-  mpi4py_comm() = default;
-  mpi4py_comm(MPI_Comm value) : value(value) {}
-  operator MPI_Comm () { return value; }
-
-  MPI_Comm value;
-};
-
-// Define the type caster
-namespace pybind11 { namespace detail {
-  template <> struct type_caster<mpi4py_comm> {
-    public:
-      PYBIND11_TYPE_CASTER(mpi4py_comm, _("mpi4py_comm"));
-
-      // Python -> C++
-      bool load(handle src, bool) {
-        PyObject *py_src = src.ptr();
-
-        // Check that we have been passed an mpi4py communicator
-        if (PyObject_TypeCheck(py_src, &PyMPIComm_Type)) {
-          // Convert to regular MPI communicator
-          value.value = *PyMPIComm_Get(py_src);
-        } else {
-          return false;
-        }
-
-        return !PyErr_Occurred();
-      }
-
-      // C++ -> Python
-      static handle cast(mpi4py_comm src,
-                         return_value_policy /* policy */,
-                         handle /* parent */)
-      {
-        // Create an mpi4py handle
-        return PyMPIComm_New(src.value);
-      }
-  };
-}} // namespace pybind11::detail
-
 namespace{
 
 using scalar_t  = double;
@@ -64,13 +22,27 @@ void _myfunc(py_f_arr vec) {
   std::cout << "my fancy func impl in C++\n";
 }
 
-// Recieve a communicator and check if it equals MPI_COMM_WORLD
-std::string _print_comm(mpi4py_comm comm) {
-  if (comm == MPI_COMM_WORLD) {
-    return "C++ received the world";
-  } else {
-    return "C++ received something else.";
-  }
+MPI_Comm* get_mpi_comm(py::object py_comm) {
+  auto comm_ptr = PyMPIComm_Get(py_comm.ptr());
+
+  if (!comm_ptr)
+    throw py::error_already_set();
+
+  return comm_ptr;
+}
+
+// Recieve a communicator, print some attributes of it, and return the memory address (to compare to Python)
+uintptr_t _print_comm(MPI_Comm* comm_ptr) {
+  MPI_Comm& comm = *comm_ptr;
+  int size = 0;
+  MPI_Comm_size(comm, &size);
+
+  int rank = 0;
+  MPI_Comm_rank(comm, &rank);
+
+  uintptr_t int_comm_ptr = reinterpret_cast<uintptr_t>(comm_ptr);
+
+  return int_comm_ptr;
 }
 }
 
@@ -82,9 +54,11 @@ PYBIND11_MODULE(MODNAME, mParent)
   }
 
   mParent.def("_myfunc", &_myfunc);
-  mParent.def("_print_comm", &_print_comm);
-
-  //mParent.def("max", &max);
+  mParent.def("_print_comm",
+              [](py::object py_comm) {
+                auto comm_ptr = get_mpi_comm(py_comm);
+                return _print_comm(comm_ptr);;
+              });
 };
 
 #endif

--- a/src/main_binder.cc
+++ b/src/main_binder.cc
@@ -20,7 +20,6 @@ using py_f_arr  = pybind11::array_t<scalar_t, pybind11::array::f_style>;
 // Simple function to serial bindings
 std::string _myfunc(py_f_arr vec) {
   std::string status = "Using C++ bindings";
-  std::cout << status << std::endl;
   return status;
 }
 

--- a/src/main_binder.cc
+++ b/src/main_binder.cc
@@ -19,7 +19,7 @@ using py_f_arr  = pybind11::array_t<scalar_t, pybind11::array::f_style>;
 
 // Simple function to serial bindings
 void _myfunc(py_f_arr vec) {
-  std::cout << "my fancy func impl in C++\n";
+  std::cout << "Using C++ bindings";
 }
 
 MPI_Comm* get_mpi_comm(py::object py_comm) {

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -5,14 +5,24 @@ import mpi4py
 
 from pressiolinalg.linalg import *
 
-# TESTING MYFUNC
+python_only = True
+cpp_bindings = False
+
+if os.environ.get('PRESSIO-LINALG-CPP'):
+    cpp_bindings = True
+    python_only = False
+
+# TESTING MYFUNC (makes sure install process worked)
 def test_myfunc():
     vector = np.arange(1,10)
     func = myfunc(vector)
-    assert 2 == 2 # this test is temporary
+    if python_only:
+        assert func == "Using only Python"
+    elif cpp_bindings:
+        assert func == "Using C++ bindings"
 
 # TESTING PRINT_COMM
-def test_print_comm:
+def test_print_comm():
     comm = MPI.COMM_WORLD
     comm_address = hex(MPI._addressof(comm))
     ftn_address = hex(print_comm(comm))

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -8,7 +8,7 @@ from pressiolinalg.linalg import *
 python_only = True
 cpp_bindings = False
 
-if os.environ.get('PRESSIO-LINALG-CPP'):
+if os.environ.get('PRESSIO_LINALG_CPP'):
     cpp_bindings = True
     python_only = False
 
@@ -16,6 +16,7 @@ if os.environ.get('PRESSIO-LINALG-CPP'):
 def test_myfunc():
     vector = np.arange(1,10)
     func = myfunc(vector)
+    print(f"func: {func}")
     if python_only:
         assert func == "Using only Python"
     elif cpp_bindings:

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -8,7 +8,7 @@ from pressiolinalg.linalg import *
 python_only = True
 cpp_bindings = False
 
-if os.environ.get('PRESSIO_LINALG_CPP'):
+if os.environ.get("PRESSIO_LINALG_CPP"):
     cpp_bindings = True
     python_only = False
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -16,7 +16,7 @@ if os.environ.get("PRESSIO_LINALG_CPP"):
 def test_myfunc():
     vector = np.arange(1,10)
     func = myfunc(vector)
-    print(f"func: {func}")
+    print(f"Output: {func}")
     if python_only:
         assert func == "Using only Python"
     elif cpp_bindings:

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -6,17 +6,22 @@ import mpi4py
 from pressiolinalg.linalg import *
 
 # TESTING MYFUNC
-print("Testing myfunc")
-vector = np.arange(1,10)
-func = myfunc(vector)
+def test_myfunc():
+    vector = np.arange(1,10)
+    func = myfunc(vector)
+    assert 2 == 2 # this test is temporary
 
 # TESTING PRINT_COMM
-print("\nTesting print_comm")
-comm = MPI.COMM_WORLD
-comm_address = hex(MPI._addressof(comm))
-ftn_address = hex(print_comm(comm))
+def test_print_comm:
+    comm = MPI.COMM_WORLD
+    comm_address = hex(MPI._addressof(comm))
+    ftn_address = hex(print_comm(comm))
 
-print(f"    comm address:     {comm_address}")
-print(f"    function address: {ftn_address}")
+    print(f"    comm address:     {comm_address}")
+    print(f"    function address: {ftn_address}")
 
-assert ftn_address == comm_address, f"{ftn_address} != {comm_address}"
+    assert ftn_address == comm_address, f"{ftn_address} != {comm_address}"
+
+if __name__ == "__main__":
+    test_myfunc()
+    test_print_comm()

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -5,13 +5,18 @@ import mpi4py
 
 from pressiolinalg.linalg import *
 
+# TESTING MYFUNC
+print("Testing myfunc")
 vector = np.arange(1,10)
 func = myfunc(vector)
 
+# TESTING PRINT_COMM
+print("\nTesting print_comm")
 comm = MPI.COMM_WORLD
-output = print_comm(comm)
-print(output)
-# if os.environ["PRESSIO_LINALG_CPP"] == "1":
-#     assert(output == "C++ received the world")
-# else:
-#     assert(output == "Python received the world")
+comm_address = hex(MPI._addressof(comm))
+ftn_address = hex(print_comm(comm))
+
+print(f"    comm address:     {comm_address}")
+print(f"    function address: {ftn_address}")
+
+assert ftn_address == comm_address, f"{ftn_address} != {comm_address}"


### PR DESCRIPTION
The main goal of this PR is to ensure that the MPI comm passed from Python to C++ is the same (rather than a duplicate). For now, I have implemented this with a lambda expression.

The lambda is necessary because openmpi and mpich use different types for their MPI objects (void* vs int*), so in order to pass the comm by reference we use the `auto` type in the lambda expression